### PR TITLE
Add Entity Framework Core support to MusicStore project

### DIFF
--- a/MusicStore/MusicStore.csproj
+++ b/MusicStore/MusicStore.csproj
@@ -8,6 +8,16 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Added the following package references to MusicStore.csproj:
- Microsoft.EntityFrameworkCore 9.0.0
- Microsoft.EntityFrameworkCore.Design 9.0.0 (PrivateAssets=all, IncludeAssets=runtime; build; native; contentfiles; analyzers; buildtransitive)
- Microsoft.EntityFrameworkCore.SqlServer 9.0.0
- Microsoft.EntityFrameworkCore.Tools 9.0.0 (PrivateAssets=all, IncludeAssets=runtime; build; native; contentfiles; analyzers; buildtransitive)

These changes enable the use of Entity Framework Core for database operations and migrations.