### PR TITLE
Update connection string in appsettings.json

### DIFF
--- a/MusicStore/appsettings.json
+++ b/MusicStore/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "MusicStoreContext": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=AlbumDb;Integrated Security=True;Connect Timeout=30;Encrypt=False;Trust Server Certificate=False;Application Intent=ReadWrite;Multi Subnet Failover=False"
+    "MusicStoreContext": "Server=localhost,1433;Database=AlbumDb;User ID=sa;Password=Password626!;Trust Server Certificate=True;"
   },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
Changed MusicStoreContext connection string from localdb to SQL Server instance on localhost:1433 with user ID 'sa' and password 'Password626!'. Enabled 'Trust Server Certificate'. In order to connect with Dockerised Database.