### PR TITLE
Add Docker Compose support and new album endpoint

### DIFF
--- a/MusicStore.sln
+++ b/MusicStore.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.12.35527.113 d17.12
+VisualStudioVersion = 17.12.35527.113
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MusicStore", "MusicStore\MusicStore.csproj", "{0A7FC34A-04DC-4077-9980-8B6D73DD0B90}"
+EndProject
+Project("{E53339B2-1760-4266-BCC7-CA923CBCF16C}") = "docker-compose", "docker-compose.dcproj", "{5D37AD0B-41F8-4084-B99B-2BFA16C3D448}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{0A7FC34A-04DC-4077-9980-8B6D73DD0B90}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A7FC34A-04DC-4077-9980-8B6D73DD0B90}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0A7FC34A-04DC-4077-9980-8B6D73DD0B90}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D37AD0B-41F8-4084-B99B-2BFA16C3D448}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D37AD0B-41F8-4084-B99B-2BFA16C3D448}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D37AD0B-41F8-4084-B99B-2BFA16C3D448}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D37AD0B-41F8-4084-B99B-2BFA16C3D448}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MusicStore/Dockerfile
+++ b/MusicStore/Dockerfile
@@ -20,7 +20,7 @@ RUN dotnet build "MusicStore.csproj" -c $BUILD_CONFIGURATION -o /app/build
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./MusicStore.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "MusicStore.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final

--- a/MusicStore/MusicStore.csproj
+++ b/MusicStore/MusicStore.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>532e688b-2e70-4ca0-8ca5-592679218a84</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MusicStore/Program.cs
+++ b/MusicStore/Program.cs
@@ -51,6 +51,13 @@ app.MapGet("/albums", async (AlbumContext db) =>
     return await db.Albums.ToListAsync();
 });
 
+app.MapPost("/albums", async (Album album, AlbumContext db) =>
+{
+    db.Albums.Add(album);
+    await db.SaveChangesAsync();
+    return Results.Created($"/albums/{album.Id}", album);
+});
+
 var summaries = new[]
 {
     "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"

--- a/MusicStore/appsettings.json
+++ b/MusicStore/appsettings.json
@@ -6,7 +6,7 @@
     }
   },
   "ConnectionStrings": {
-    "MusicStoreContext": "Server=localhost,1433;Database=AlbumDb;User ID=sa;Password=Password626!;Trust Server Certificate=True;"
+    "MusicStoreContext": "Server=sqlserver;Database=AlbumDb;User ID=sa;Password=Password626!;Trust Server Certificate=True;"
   },
   "AllowedHosts": "*"
 }

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" Sdk="Microsoft.Docker.Sdk">
+  <PropertyGroup Label="Globals">
+    <ProjectVersion>2.1</ProjectVersion>
+    <DockerTargetOS>Linux</DockerTargetOS>
+    <DockerPublishLocally>False</DockerPublishLocally>
+    <ProjectGuid>5d37ad0b-41f8-4084-b99b-2bfa16c3d448</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="docker-compose.override.yml">
+      <DependentUpon>docker-compose.yml</DependentUpon>
+    </None>
+    <None Include="docker-compose.yml" />
+    <None Include=".dockerignore" />
+  </ItemGroup>
+</Project>

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,12 @@
+services:
+  musicstore:
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_HTTP_PORTS=8080
+      - ASPNETCORE_HTTPS_PORTS=8081
+    ports:
+      - "8080"
+      - "8081"
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/home/app/.microsoft/usersecrets:ro
+      - ${APPDATA}/ASP.NET/Https:/home/app/.aspnet/https:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  musicstore:
+    build:
+      context: ./MusicStore
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    depends_on:
+      - sqlserver 
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    networks:
+      - music-network
+    restart: on-failure
+
+  sqlserver:
+    image: "mcr.microsoft.com/mssql/server:2022-latest"
+    environment:
+      SA_PASSWORD: "Password626!"
+      ACCEPT_EULA: "Y"
+    ports:
+      - "1433:1433"
+    volumes:
+     - sqlvolume:/var/opt/mssql
+    networks:
+      - music-network
+
+networks:
+  music-network:
+
+volumes:
+   sqlvolume:

--- a/launchSettings.json
+++ b/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "Docker Compose": {
+      "commandName": "DockerCompose",
+      "commandVersion": "1.0",
+      "serviceActions": {
+        "musicstore": "StartDebugging"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Updated solution to include Docker Compose project for container management.
- Corrected `dotnet publish` command in `Dockerfile`.
- Added Docker Compose project reference in `MusicStore.csproj`.
- Added HTTP POST endpoint in `Program.cs` for adding albums.
- Changed DB connection string in `appsettings.json` to `sqlserver`.
- Added `docker-compose.dcproj` for Docker Compose configuration.
- Added `docker-compose.override.yml` for development settings.
- Added `docker-compose.yml` to define services and settings.
- Added `launchSettings.json` for Docker Compose debugging.